### PR TITLE
Add compare-objects project and tests.

### DIFF
--- a/.NET/compare-objects-tests/ParticleWithEqualsTests.cs
+++ b/.NET/compare-objects-tests/ParticleWithEqualsTests.cs
@@ -1,0 +1,95 @@
+using Xunit;
+
+namespace compare_objects_tests
+{
+    public class ParticleWithEqualsTests
+    {
+        [Fact]
+        public void Equals_StructsHaveEqualValueFieldAndTheSameReferenceObject_ReturnsTrue()
+        {
+            //Arrange
+            var internalData = new InternalData();
+            var x = 7;
+
+            var particle1 = new ParticleWithEquals(x, internalData);
+            var particle2 = new ParticleWithEquals(x, internalData);
+
+            //Act
+            var result = particle1.Equals(particle2);
+
+            //Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Equals_StructsHaveNotEqualValueFieldAndTheSameReferenceObject_ReturnsFalse()
+        {
+            //Arrange
+            var internalData = new InternalData();
+            var x1 = 7;
+            var x2 = 8;
+
+            var particle1 = new ParticleWithEquals(x1, internalData);
+            var particle2 = new ParticleWithEquals(x2, internalData);
+
+            //Act
+            var result = particle1.Equals(particle2);
+
+            //Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Equals_StructsHaveEqualValueFieldAndDifferentReferenceObject_ReturnsFalse()
+        {
+            //Arrange
+            var internalData1 = new InternalData();
+            var internalData2 = new InternalData();
+            var x = 7;
+
+            var particle1 = new ParticleWithEquals(x, internalData1);
+            var particle2 = new ParticleWithEquals(x, internalData2);
+
+            //Act
+            var result = particle1.Equals(particle2);
+
+            //Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Equals_StructsHaveNotEqualValueFieldAndDifferentReferenceObject_ReturnsFalse()
+        {
+            //Arrange
+            var internalData1 = new InternalData();
+            var internalData2 = new InternalData();
+            var x1 = 7;
+            var x2 = 8;
+
+            var particle1 = new ParticleWithEquals(x1, internalData1);
+            var particle2 = new ParticleWithEquals(x2, internalData2);
+
+            //Act
+            var result = particle1.Equals(particle2);
+
+            //Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Equals_StructAndNull_ReturnsFalse()
+        {
+            //Arrange
+            var internalData = new InternalData();
+            var x = 7;
+
+            var particle = new ParticleWithEquals(x, internalData);
+
+            //Act
+            var result = particle.Equals(null);
+
+            //Assert
+            Assert.False(result);
+        }
+    }
+}

--- a/.NET/compare-objects-tests/ParticleWithoutEqualsTests.cs
+++ b/.NET/compare-objects-tests/ParticleWithoutEqualsTests.cs
@@ -1,0 +1,95 @@
+﻿using Xunit;
+
+namespace compare_objects_tests
+{
+    public class ParticleWithoutEqualsTests
+    {
+        [Fact]
+        public void Equals_StructsHaveEqualValueFieldAndTheSameReferenceObject_ReturnsTrue()
+        {
+            //Arrange
+            var internalData = new InternalData();
+            var x = 7;
+
+            var particle1 = new ParticleWithoutEquals(x, internalData);
+            var particle2 = new ParticleWithoutEquals(x, internalData);
+
+            //Act
+            var result = particle1.Equals(particle2);
+
+            //Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Equals_StructsHaveNotEqualValueFieldAndTheSameReferenceObject_ReturnsFalse()
+        {
+            //Arrange
+            var internalData = new InternalData();
+            var x1 = 7;
+            var x2 = 8;
+
+            var particle1 = new ParticleWithoutEquals(x1, internalData);
+            var particle2 = new ParticleWithoutEquals(x2, internalData);
+
+            //Act
+            var result = particle1.Equals(particle2);
+
+            //Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Equals_StructsHaveEqualValueFieldAndDifferentReferenceObject_ReturnsFalse()
+        {
+            //Arrange
+            var internalData1 = new InternalData();
+            var internalData2 = new InternalData();
+            var x = 7;
+
+            var particle1 = new ParticleWithoutEquals(x, internalData1);
+            var particle2 = new ParticleWithoutEquals(x, internalData2);
+
+            //Act
+            var result = particle1.Equals(particle2);
+
+            //Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Equals_StructsHaveNotEqualValueFieldAndDifferentReferenceObject_ReturnsFalse()
+        {
+            //Arrange
+            var internalData1 = new InternalData();
+            var internalData2 = new InternalData();
+            var x1 = 7;
+            var x2 = 8;
+
+            var particle1 = new ParticleWithoutEquals(x1, internalData1);
+            var particle2 = new ParticleWithoutEquals(x2, internalData2);
+
+            //Act
+            var result = particle1.Equals(particle2);
+
+            //Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Equals_StructAndNull_ReturnsFalse()
+        {
+            //Arrange
+            var internalData = new InternalData();
+            var x = 7;
+
+            var particle = new ParticleWithoutEquals(x, internalData);
+
+            //Act
+            var result = particle.Equals(null);
+
+            //Assert
+            Assert.False(result);
+        }
+    }
+}

--- a/.NET/compare-objects-tests/compare-objects-tests.csproj
+++ b/.NET/compare-objects-tests/compare-objects-tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <RootNamespace>compare_objects_tests</RootNamespace>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\compare-objects\compare-objects.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/.NET/compare-objects/Diagnostic.cs
+++ b/.NET/compare-objects/Diagnostic.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace compare_objects
+{
+    public class Diagnostic
+    {
+        private readonly (ParticleWithEquals, ParticleWithEquals) _particlesWithEqualsToCompare;
+        private readonly (ParticleWithoutEquals, ParticleWithoutEquals) _particlesWithoutEqualsToCompare;
+        private readonly int _equalsOperationCount;
+
+        public Diagnostic(
+            (ParticleWithEquals, ParticleWithEquals) particlesWithEqualsToCompare,
+            (ParticleWithoutEquals, ParticleWithoutEquals) particlesWithoutEqualsToCompare,
+            int equalsOperationCount
+        )
+        {
+            _particlesWithEqualsToCompare = particlesWithEqualsToCompare;
+            _particlesWithoutEqualsToCompare = particlesWithoutEqualsToCompare;
+            _equalsOperationCount = equalsOperationCount;
+        }
+
+        public void MeasureExecutionTimeWithEquals()
+        {
+            Console.WriteLine("Structs with Equals method overriden");
+
+            int i = 0;
+
+            var stopwatch = new Stopwatch();
+
+            stopwatch.Start();
+
+            while (i < _equalsOperationCount)
+            {
+                _particlesWithEqualsToCompare.Item1.Equals(_particlesWithEqualsToCompare.Item2);
+                ++i;
+            }
+
+            stopwatch.Stop();
+
+            Console.WriteLine("Elapsed={0}", stopwatch.Elapsed);
+        }
+
+        public void MeasureExecutionTimeWithoutEquals()
+        {
+            Console.WriteLine("Structs without Equals method overriden");
+
+            int i = 0;
+
+            var stopwatch = new Stopwatch();
+
+            stopwatch.Start();
+
+            while (i < _equalsOperationCount)
+            {
+                _particlesWithoutEqualsToCompare.Item1.Equals(_particlesWithoutEqualsToCompare.Item2);
+                ++i;
+            }
+
+            stopwatch.Stop();
+
+            Console.WriteLine("Elapsed={0}", stopwatch.Elapsed);
+        }
+    }
+}

--- a/.NET/compare-objects/InternalData.cs
+++ b/.NET/compare-objects/InternalData.cs
@@ -1,0 +1,4 @@
+﻿public class InternalData
+{
+    public InternalData() { }
+}

--- a/.NET/compare-objects/ParticleWithEquals.cs
+++ b/.NET/compare-objects/ParticleWithEquals.cs
@@ -1,0 +1,22 @@
+﻿public struct ParticleWithEquals
+{
+    private readonly int _x;
+    private readonly InternalData _internalData;
+
+    public ParticleWithEquals(int x, InternalData internalData)
+    {
+        _x = x;
+        _internalData = internalData;
+    }
+
+    public override bool Equals(object obj) =>
+        obj is ParticleWithEquals particleWithEquals &&
+        Equals(particleWithEquals);
+
+    public bool Equals(ParticleWithEquals particleWithEquals) =>
+        particleWithEquals._x.Equals(_x) &&
+        particleWithEquals._internalData.Equals(_internalData);
+
+    public override int GetHashCode() =>
+        _x.GetHashCode() ^ _internalData.GetHashCode();
+}

--- a/.NET/compare-objects/ParticleWithoutEquals.cs
+++ b/.NET/compare-objects/ParticleWithoutEquals.cs
@@ -1,0 +1,11 @@
+﻿public struct ParticleWithoutEquals
+{
+    private readonly int _x;
+    private readonly InternalData _internalData;
+
+    public ParticleWithoutEquals(int x, InternalData internalData)
+    {
+        _x = x;
+        _internalData = internalData;
+    }
+}

--- a/.NET/compare-objects/Program.cs
+++ b/.NET/compare-objects/Program.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace compare_objects
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var equalsOperationCount = 1_000_000_000;
+
+            var obj = new InternalData();
+            var particlesWithEquals = (new ParticleWithEquals(1, obj), new ParticleWithEquals(1, obj));
+            var particlesWithoutEquals = (new ParticleWithoutEquals(1, obj), new ParticleWithoutEquals(1, obj));
+
+            var diagnostic = new Diagnostic(particlesWithEquals, particlesWithoutEquals, equalsOperationCount);
+            diagnostic.MeasureExecutionTimeWithEquals();
+            diagnostic.MeasureExecutionTimeWithoutEquals();
+        }
+    }
+}

--- a/.NET/compare-objects/compare-objects.csproj
+++ b/.NET/compare-objects/compare-objects.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <RootNamespace>compare_objects</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/.NET/dotnet.sln
+++ b/.NET/dotnet.sln
@@ -9,6 +9,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nsubstitute_1", "nsubstitut
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nsubstitute_1-tests", "nsubstitute_1-tests\nsubstitute_1-tests.csproj", "{2A1B530A-7A02-4A7D-8D6A-01E7BDD03DA9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "compare-objects", "compare-objects\compare-objects.csproj", "{9B56E2DE-EDEA-40E6-B548-2359FA424714}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "compare-objects-tests", "compare-objects-tests\compare-objects-tests.csproj", "{40601FF4-D6E3-413A-B0B2-B580B1562388}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +31,14 @@ Global
 		{2A1B530A-7A02-4A7D-8D6A-01E7BDD03DA9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2A1B530A-7A02-4A7D-8D6A-01E7BDD03DA9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2A1B530A-7A02-4A7D-8D6A-01E7BDD03DA9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B56E2DE-EDEA-40E6-B548-2359FA424714}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B56E2DE-EDEA-40E6-B548-2359FA424714}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B56E2DE-EDEA-40E6-B548-2359FA424714}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B56E2DE-EDEA-40E6-B548-2359FA424714}.Release|Any CPU.Build.0 = Release|Any CPU
+		{40601FF4-D6E3-413A-B0B2-B580B1562388}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{40601FF4-D6E3-413A-B0B2-B580B1562388}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{40601FF4-D6E3-413A-B0B2-B580B1562388}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{40601FF4-D6E3-413A-B0B2-B580B1562388}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR adds the "compare-objects" project alongside with its tests. The "compare-objects" projects measures the time for Equals method invocation for structure that has at least one field of reference type. Two cases are considered
- Equals method is overridden.
- Equals method is not overridden.